### PR TITLE
Freed two variables that when calling function: watershed created a memo...

### DIFF
--- a/generic/imgraph.c
+++ b/generic/imgraph.c
@@ -799,6 +799,8 @@ static int imgraph_(watershed)(lua_State *L) {
 
   // cleanup
   freeimage(input_xv);
+  freeimage(labels_xv);
+  freeimage(filtered_xv);
   THTensor_(free)(inputc);
 
   // return number of components


### PR DESCRIPTION
...ry leak

Tested that the watershed outcome with freeimage lines added is the same as before.
